### PR TITLE
ci: stop running every commit twice

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,12 @@
 name: Go
-on: [pull_request, push]
+
+# Pull requests cover branches; push covers main. Listing both unscoped ran everything twice —
+# pushing to a branch with an open PR fires `push` for the branch ref AND `pull_request`
+# (synchronize) for the moved head, so every commit built the same SHA in two identical runs.
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 # This repo predates GitHub's 2023 switch to a read-only default, so GITHUB_TOKEN would otherwise
 # resolve to Contents/Actions/Deployments: write and be handed to every third-party action in the


### PR DESCRIPTION
`on: [pull_request, push]` fires **both** events when you push to a branch with an open PR: `push` because the branch ref moved, and `pull_request` (`synchronize`) because the PR head moved. Every commit therefore built the same SHA in two identical runs.

Observed on #3:

```
22:45:15  pull_request  508f5ee  success
22:45:13  push          508f5ee  success   <- same SHA, 2s apart
22:31:43  pull_request  1036cb7  success
22:31:41  push          1036cb7  success
```

Three jobs each, so six runs per commit instead of three.

## Change

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

The two triggers now cover disjoint cases:

- push to a branch with an open PR -> `pull_request` only
- push to `main` (a merge landing) -> `push` only

Nothing loses coverage.

## Trade-off

A branch with no PR open no longer gets CI until one is opened. That's the usual trade for this fix, and matches the intent: run CI for PRs, and for merges to main.