### PR TITLE
fix(make): make the coverage targets actually work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 # The binary name.
 BINARY ?= prettycov
 
-# This repo's root import path.
-PKG := github.com/screwyprof/prettycov
-
 ## DO NOT EDIT BELLOW THIS LINE
-GO_FILES = $(shell find . -name "*.go" | grep -v vendor | uniq)
+GO_FILES := $(shell find . -name "*.go" -not -path "./.direnv/*" | grep -v vendor | uniq)
 LOCAL_PACKAGES="github.com/screwyprof/prettycov"
+COVERAGE := coverage.out
 
 # ./VERSION is the single source of truth: flake.nix reads the same file, and `make release` tags
 # from it. Dev builds still carry the commit, so binaries report e.g. v0.1.3+abc1234.
@@ -30,7 +28,11 @@ else
 	OPEN := xdg-open
 endif
 
+# bash, not sh: `echo -e` below prints a literal "-e" under dash, which is /bin/sh on the Ubuntu
+# runners. -e -o pipefail applies to every recipe line, so a failing command anywhere in a pipe
+# fails the target — without it `go tool cover ... | column` reported success when cover errored.
 SHELL := bash
+.SHELLFLAGS := -eu -o pipefail -c
 
 OK_COLOR=\033[32;01m
 NO_COLOR=\033[0m
@@ -47,28 +49,36 @@ fmt: ## format code
 	@gofumpt -l -w .
 	@gci write $(GO_FILES) -s standard  -s default -s "prefix($(LOCAL_PACKAGES))"
 
-test:
+test: ## run tests and write the coverage profile
 	@echo -e "$(OK_COLOR)==> Running tests$(NO_COLOR)"
-	@set -euo pipefail && go test -json -v -race -count=1 -timeout=120s -cover -covermode atomic -coverprofile=coverage.out ./... | tparse -follow
+	@go test -json -v -race -count=1 -timeout=120s -cover -covermode atomic -coverprofile=$(COVERAGE) ./... | tparse -follow
 
-test-cover-txt: ## show plain coverage report in console
+# The reports below read the profile, so they need one to exist. Depending on the file rather than
+# on `test` means a report regenerates it when absent but reuses it when present, instead of
+# re-running the whole suite every time you want to look at the numbers again.
+$(COVERAGE):
+	@$(MAKE) --no-print-directory test
+
+test-cover-txt: $(COVERAGE) ## show plain coverage report in console
 	@echo -e "$(OK_COLOR)==> Generating coverage report$(NO_COLOR)"
-	@go tool cover -func coverage.out | tr -s '\t' ' ' | column -t -c2
+	@go tool cover -func $(COVERAGE) | tr -s '\t' ' ' | column -t -c2
 
 # Written to a file rather than handed straight to a browser, so the report survives on a machine
 # with no display instead of the target silently doing nothing. Same best-effort open as the SVG.
-test-cover-html: ## show html coverage report
+test-cover-html: $(COVERAGE) ## show html coverage report
 	@echo -e "$(OK_COLOR)==> Generating coverage report$(NO_COLOR)"
-	@go tool cover -html=coverage.out -o coverage.html
+	@go tool cover -html=$(COVERAGE) -o coverage.html
 	@$(OPEN) coverage.html 2>/dev/null || echo "==> coverage.html written ($(OPEN) unavailable)"
 
-test-cover-total: # show total coverage.out
+# Statements, not lines: Go instruments statements, so this will not match a line-based service
+# such as codecov.
+test-cover-total: $(COVERAGE) ## show total coverage
 	@echo -e "$(OK_COLOR)==> Total coverage:$(NO_COLOR)"
-	@go tool cover -func coverage.out  | tail -n 1 | rev | cut -f1 | rev
+	@go tool cover -func $(COVERAGE) | tail -n 1 | rev | cut -f1 | rev
 
 # Opening is best-effort: the SVG is the deliverable, and CI/containers have no display.
-test-cover-svg: # generate pretty coverage picture
-	@go-cover-treemap -coverprofile coverage.out > coverage.svg
+test-cover-svg: $(COVERAGE) ## generate pretty coverage picture
+	@go-cover-treemap -coverprofile $(COVERAGE) > coverage.svg
 	@$(OPEN) coverage.svg 2>/dev/null || echo "==> coverage.svg written ($(OPEN) unavailable)"
 
 lint: ## run linters for current changes
@@ -97,7 +107,7 @@ FAKE_HASH := sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 nix-hash: ## recompute flake.nix vendorHash (run after go.mod/go.sum change)
 	@echo -e "$(OK_COLOR)==> Recomputing vendorHash$(NO_COLOR)"
 	@sed -i.bak -E 's|vendorHash = "sha256-[^"]*"|vendorHash = "$(FAKE_HASH)"|' flake.nix
-	@hash=$$(nix build --no-link .#default 2>&1 | grep -oE 'sha256-[A-Za-z0-9+/=]{44}' | grep -v '^$(FAKE_HASH)$$' | head -1); \
+	@hash=$$( { nix build --no-link .#default 2>&1 || true; } | grep -oE 'sha256-[A-Za-z0-9+/=]{44}' | grep -v '^$(FAKE_HASH)$$' | head -1 || true); \
 	if [ -z "$$hash" ]; then \
 		echo "could not determine vendorHash; restoring"; mv flake.nix.bak flake.nix; exit 1; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ endif
 SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
 
+# `go test -coverprofile` writes the profile even when the suite fails, so without this a failed
+# run leaves a partial coverage.out behind and the next report reads it and exits 0.
+.DELETE_ON_ERROR:
+
+# Nothing here gains from -j, and coverage.out has one producer that several targets can ask for.
+# Serialising removes any chance of two runs writing that file at once.
+.NOTPARALLEL:
+
 OK_COLOR=\033[32;01m
 NO_COLOR=\033[0m
 MAKE_COLOR=\033[36m%-20s\033[0m
@@ -49,15 +57,18 @@ fmt: ## format code
 	@gofumpt -l -w .
 	@gci write $(GO_FILES) -s standard  -s default -s "prefix($(LOCAL_PACKAGES))"
 
-test: ## run tests and write the coverage profile
+# One recipe produces the profile, and it is a real file rule so make can tell when it is stale.
+# The reports depend on the file rather than on `test`, so they rebuild it when a source has
+# changed and reuse it otherwise, instead of re-running the suite to re-read the same numbers.
+$(COVERAGE): $(GO_FILES)
 	@echo -e "$(OK_COLOR)==> Running tests$(NO_COLOR)"
-	@go test -json -v -race -count=1 -timeout=120s -cover -covermode atomic -coverprofile=$(COVERAGE) ./... | tparse -follow
+	@go test -json -v -race -count=1 -timeout=120s -cover -covermode atomic -coverprofile=$@ ./... | tparse -follow
 
-# The reports below read the profile, so they need one to exist. Depending on the file rather than
-# on `test` means a report regenerates it when absent but reuses it when present, instead of
-# re-running the whole suite every time you want to look at the numbers again.
-$(COVERAGE):
-	@$(MAKE) --no-print-directory test
+# `make test` must always run the suite, so it drops the profile first rather than letting make
+# decide it is up to date.
+test: ## run tests and write the coverage profile
+	@rm -f $(COVERAGE)
+	@$(MAKE) --no-print-directory $(COVERAGE)
 
 test-cover-txt: $(COVERAGE) ## show plain coverage report in console
 	@echo -e "$(OK_COLOR)==> Generating coverage report$(NO_COLOR)"
@@ -65,10 +76,12 @@ test-cover-txt: $(COVERAGE) ## show plain coverage report in console
 
 # Written to a file rather than handed straight to a browser, so the report survives on a machine
 # with no display instead of the target silently doing nothing. Same best-effort open as the SVG.
-test-cover-html: $(COVERAGE) ## show html coverage report
+coverage.html: $(COVERAGE)
 	@echo -e "$(OK_COLOR)==> Generating coverage report$(NO_COLOR)"
-	@go tool cover -html=$(COVERAGE) -o coverage.html
-	@$(OPEN) coverage.html 2>/dev/null || echo "==> coverage.html written ($(OPEN) unavailable)"
+	@go tool cover -html=$< -o $@
+
+test-cover-html: coverage.html ## show html coverage report
+	@$(OPEN) $< 2>/dev/null || echo "==> $< written ($(OPEN) unavailable)"
 
 # Statements, not lines: Go instruments statements, so this will not match a line-based service
 # such as codecov.
@@ -76,10 +89,12 @@ test-cover-total: $(COVERAGE) ## show total coverage
 	@echo -e "$(OK_COLOR)==> Total coverage:$(NO_COLOR)"
 	@go tool cover -func $(COVERAGE) | tail -n 1 | rev | cut -f1 | rev
 
+coverage.svg: $(COVERAGE)
+	@go-cover-treemap -coverprofile $< > $@
+
 # Opening is best-effort: the SVG is the deliverable, and CI/containers have no display.
-test-cover-svg: $(COVERAGE) ## generate pretty coverage picture
-	@go-cover-treemap -coverprofile $(COVERAGE) > coverage.svg
-	@$(OPEN) coverage.svg 2>/dev/null || echo "==> coverage.svg written ($(OPEN) unavailable)"
+test-cover-svg: coverage.svg ## generate pretty coverage picture
+	@$(OPEN) $< 2>/dev/null || echo "==> $< written ($(OPEN) unavailable)"
 
 lint: ## run linters for current changes
 	@echo -e "$(OK_COLOR)==> Linting current changes$(NO_COLOR)"

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,6 @@ OK_COLOR=\033[32;01m
 NO_COLOR=\033[0m
 MAKE_COLOR=\033[36m%-20s\033[0m
 
-IGNORE_COVERAGE_FOR=-e .*_gen.go -e backend-server.go -e  backend-types.go -e internal -e pkg/web3signer/client -e pkg/eth2/spec -e test_helpers.go -e .*test
-
 all: build lint test ## build application, run linters and tests
 
 build: ## build application
@@ -51,16 +49,18 @@ fmt: ## format code
 
 test:
 	@echo -e "$(OK_COLOR)==> Running tests$(NO_COLOR)"
-	@set -euo pipefail && go test -json -v -race -count=1 -timeout=120s -cover -covermode atomic -coverprofile=coverage.tmp ./... | tparse -follow
-	@set -euo pipefail && cat coverage.tmp | grep -v $(IGNORE_COVERAGE_FOR) > coverage.out && rm coverage.tmp
+	@set -euo pipefail && go test -json -v -race -count=1 -timeout=120s -cover -covermode atomic -coverprofile=coverage.out ./... | tparse -follow
 
 test-cover-txt: ## show plain coverage report in console
 	@echo -e "$(OK_COLOR)==> Generating coverage report$(NO_COLOR)"
 	@go tool cover -func coverage.out | tr -s '\t' ' ' | column -t -c2
 
+# Written to a file rather than handed straight to a browser, so the report survives on a machine
+# with no display instead of the target silently doing nothing. Same best-effort open as the SVG.
 test-cover-html: ## show html coverage report
 	@echo -e "$(OK_COLOR)==> Generating coverage report$(NO_COLOR)"
-	@go tool cover -html=coverage.out
+	@go tool cover -html=coverage.out -o coverage.html
+	@$(OPEN) coverage.html 2>/dev/null || echo "==> coverage.html written ($(OPEN) unavailable)"
 
 test-cover-total: # show total coverage.out
 	@echo -e "$(OK_COLOR)==> Total coverage:$(NO_COLOR)"


### PR DESCRIPTION
Six problems in the coverage targets, found by running them.

## 1. Pipes swallowed failures

`set -euo pipefail` was hand-applied to `test` only, so the reports returned success when the command feeding the pipe had failed:

```
$ rm coverage.out && make test-cover-txt; echo $?
0        # printed nothing, exit 0
```

`.SHELLFLAGS := -eu -o pipefail -c` now covers every recipe line. Both exit 2.

`nix-hash` needed guarding for it — it parses a *deliberately failing* `nix build`.

## 2. A stale profile was never rebuilt

```
$ touch parser.go && make -n test-cover-txt
go tool cover -func coverage.out ...     # no test run
```

Edit a file, ask for a total, get yesterday's number at exit 0. The rule now depends on `$(GO_FILES)`.

## 3. A failed run left a partial profile

`go test -coverprofile` writes the file even when the suite fails — verified in a scratch module: exit 1, profile present with real data. So a failing run left `coverage.out` behind and the next report read it and exited 0. `.DELETE_ON_ERROR:` removes it.

## 4. Reports assumed a profile existed

They read `coverage.out` without producing it, so on a clean checkout they failed or reported stale numbers.

There is now one producer, a real file rule so make can judge staleness, and the reports depend on the file rather than on `test` — a report rebuilds it when a source changed, reuses it otherwise, instead of re-running the suite to re-read the same numbers. `test` drops the profile first so it always runs.

`coverage.html` and `coverage.svg` are file rules too, which also fixes `> coverage.svg` truncating its target before running — a failure used to leave a 0-byte file where the deliverable should be.

`.NOTPARALLEL:` since several targets can ask for `coverage.out` and nothing here gains from `-j`.

## 5. The filter was another project's boilerplate

```make
IGNORE_COVERAGE_FOR=... -e internal -e pkg/web3signer/client -e pkg/eth2/spec ... -e .*test
```

`backend-server.go`, `pkg/web3signer/client`, `pkg/eth2/spec` never existed here. A no-op on this repo, but a trap anywhere else — `-e internal` drops every `internal/` package and `-e .*test` is a substring match:

```
kept     app/pkg/api/api.go
dropped  app/internal/service/svc.go
dropped  app/testutil/helper.go
dropped  app/latest/latest.go        <- "la(test)"
```

Silently understating coverage is a poor failure mode for a coverage tool. Nothing here needs excluding — the go tool already keeps `testdata/` and `_test.go` out of profiles.

## 6. `test-cover-html` produced nothing headless

Piped straight to a browser: heading, exit 0, no file. Now writes `coverage.html` and opens it best-effort.

## Also

- `test`, `test-cover-total`, `test-cover-svg` were invisible in `make help` (`#` vs `##`). All 17 list now.
- `PKG` declared, never referenced.
- `GO_FILES` used `=`, so `find` re-ran on every expansion; now `:=`, skipping `.direnv`.
- `SHELL := bash` **stays and is load-bearing**: under dash (`/bin/sh` on the Ubuntu runners) `echo -e "x"` prints `-e x`.

## Verified

| check | result |
|---|---|
| corrupt profile -> txt / total | exit 2 (was 0) |
| `touch parser.go` -> report | rebuilds (1 `go test`) |
| nothing changed -> report | reuses (0 `go test`) |
| `make test` | always runs |
| failing suite | no profile left; next report exits 2 |
| corrupt profile -> html / svg | exit 2, no 0-byte file |
| `nix-hash` under the new flags | recovers hash correctly |
| `release` guards, `clean` | unaffected, no leftovers |

`test-cover-total` reports **statements** (51.4%) and will never match the codecov badge (~54%), which counts **lines**. Go instruments statements; the difference is the unit. Noted in a comment on the target.
