### PR TITLE
refactor: derive the coverage ratio instead of storing it

### DIFF
--- a/oracle_test.go
+++ b/oracle_test.go
@@ -37,16 +37,10 @@ func TestProcessMatchesProfileTotals(t *testing.T) {
 				node := tree.Get(dir)
 				require.NotNilf(t, node, "%q is in the profile but missing from the tree", dir)
 
+				// Counts only. The ratio is derived from these by CoverageStats.Ratio, so it
+				// cannot disagree with them — which it could when it was a stored field, and did.
 				assert.Equalf(t, want.Covered, node.Coverage.Covered, "covered statements at %q", dir)
 				assert.Equalf(t, want.Uncovered, node.Coverage.Uncovered, "uncovered statements at %q", dir)
-
-				// The counts can be right while the percentage is not: the old roll-up derived a
-				// parent's ratio from its own statements alone, ignoring the children it had just
-				// added in. Check the reported ratio actually describes the reported counts.
-				if total := want.Covered + want.Uncovered; total > 0 {
-					wantRatio := float64(want.Covered) / float64(total) * 100
-					assert.InDeltaf(t, wantRatio, node.Coverage.Ratio, ratioTolerance, "ratio at %q", dir)
-				}
 			}
 		})
 	}

--- a/parser.go
+++ b/parser.go
@@ -10,11 +10,13 @@ import (
 
 // ErrInvalidProfile reports a profile that could be read but not understood.
 //
-// The cover package offers nothing to match on: it builds every error with fmt.Errorf and %v, so
-// they carry no wrapped chain and there are no exported sentinels or types. Callers would be left
-// matching message text, which changes whenever x/tools does. This gives them something stable
-// instead. Failures to open the file keep their own cause, so errors.Is(err, fs.ErrNotExist) and
-// friends still work.
+// The cover package offers almost nothing to match on: it reports every malformed profile with
+// fmt.Errorf and %v, so those carry no wrapped chain and there is no sentinel or type behind them.
+// Callers would be left matching message text, which changes whenever x/tools does. This gives
+// them something stable instead.
+//
+// Errors that merely pass through it keep their own cause, so errors.Is still reaches them: a
+// failure to open the file, and the bufio.Scanner errors ParseProfilesFromReader returns verbatim.
 var ErrInvalidProfile = errors.New("invalid coverage profile")
 
 // ParseProfile reads a coverage profile produced by `go test -coverprofile`.

--- a/parser.go
+++ b/parser.go
@@ -8,15 +8,7 @@ import (
 	"golang.org/x/tools/cover"
 )
 
-// ErrInvalidProfile reports a profile that could be read but not understood.
-//
-// The cover package offers almost nothing to match on: it reports every malformed profile with
-// fmt.Errorf and %v, so those carry no wrapped chain and there is no sentinel or type behind them.
-// Callers would be left matching message text, which changes whenever x/tools does. This gives
-// them something stable instead.
-//
-// Errors that merely pass through it keep their own cause, so errors.Is still reaches them: a
-// failure to open the file, and the bufio.Scanner errors ParseProfilesFromReader returns verbatim.
+// ErrInvalidProfile reports a profile that could be read but not parsed.
 var ErrInvalidProfile = errors.New("invalid coverage profile")
 
 // ParseProfile reads a coverage profile produced by `go test -coverprofile`.

--- a/parser.go
+++ b/parser.go
@@ -55,7 +55,6 @@ func parse(profiles []*cover.Profile) []FileCoverage {
 			Coverage: CoverageStats{
 				Covered:   covered,
 				Uncovered: uncovered,
-				Ratio:     ratio(covered, uncovered),
 			},
 		})
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,7 +2,6 @@ package prettycov_test
 
 import (
 	"io/fs"
-	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -80,8 +79,8 @@ func TestParseProfileSumsStatementsPerFile(t *testing.T) {
 		byFile[item.File] = item.Coverage
 	}
 
-	assert.Equal(t, prettycov.CoverageStats{Covered: 3, Uncovered: 2, Ratio: 60}, byFile["m/a.go"])
-	assert.Equal(t, prettycov.CoverageStats{Covered: 4, Uncovered: 0, Ratio: 100}, byFile["m/b.go"])
+	assert.Equal(t, prettycov.CoverageStats{Covered: 3, Uncovered: 2}, byFile["m/a.go"])
+	assert.Equal(t, prettycov.CoverageStats{Covered: 4, Uncovered: 0}, byFile["m/b.go"])
 }
 
 // `go test -coverpkg` emits the same block once per test binary that loaded the package. Those
@@ -99,13 +98,13 @@ func TestParseProfileMergesRepeatedBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, items, 1)
-	assert.Equal(t, prettycov.CoverageStats{Covered: 3, Uncovered: 0, Ratio: 100}, items[0].Coverage)
+	assert.Equal(t, prettycov.CoverageStats{Covered: 3, Uncovered: 0}, items[0].Coverage)
 }
 
-// A package with no statements gets Ratio = NaN, and NaN does not equal itself, so two identical
-// results compare unequal. Pinned here so a change to it is deliberate; it also renders as the
-// literal "NaN" in the tree output.
-func TestRatioOfNoStatementsIsNaN(t *testing.T) {
+// A package with no statements must still produce a comparable result. Storing a derived ratio
+// put a NaN in the struct, and NaN does not equal itself, so two identical parses compared
+// unequal — breaking any caller that compares stats, not just the display.
+func TestCoverageStatsAreComparable(t *testing.T) {
 	t.Parallel()
 
 	path := writeProfile(t, "mode: atomic\nm/doc.go:1.1,2.2 0 0\n")
@@ -117,8 +116,7 @@ func TestRatioOfNoStatementsIsNaN(t *testing.T) {
 	second, err := prettycov.ParseProfile(path)
 	require.NoError(t, err)
 
-	assert.True(t, math.IsNaN(first[0].Coverage.Ratio), "want NaN for a package with no statements")
-	assert.NotEqual(t, first, second, "two identical parses compare unequal because of the NaN")
+	assert.Equal(t, first, second, "two identical parses must compare equal")
 }
 
 func writeProfile(t *testing.T, content string) string {

--- a/prettycov.go
+++ b/prettycov.go
@@ -8,7 +8,18 @@ import (
 type CoverageStats struct {
 	Covered   int
 	Uncovered int
-	Ratio     float64
+}
+
+// Ratio reports the percentage of statements covered. ok is false when there are none to cover,
+// which is not 0% — there is nothing to report. Derived rather than stored: a stored percentage
+// can disagree with the counts beside it, which is exactly how the roll-up used to go wrong.
+func (c CoverageStats) Ratio() (pct float64, ok bool) {
+	total := c.Covered + c.Uncovered
+	if total == 0 {
+		return 0, false
+	}
+
+	return float64(c.Covered) / float64(total) * 100, true
 }
 
 type FileCoverage struct {
@@ -19,11 +30,6 @@ type FileCoverage struct {
 type PkgCoverage struct {
 	Pkg      string
 	Coverage CoverageStats
-}
-
-// ratio returns the percentage of covered statements, or NaN when there are none.
-func ratio(covered, uncovered int) float64 {
-	return float64(covered) / float64(covered+uncovered) * 100
 }
 
 // Process turns per-file coverage into a tree in which every node reports its own statements plus
@@ -64,7 +70,6 @@ func rollUp(node *PathTree) *PathTree {
 		Coverage: CoverageStats{
 			Covered:   covered,
 			Uncovered: uncovered,
-			Ratio:     ratio(covered, uncovered),
 		},
 		Children: children,
 	}
@@ -101,7 +106,6 @@ func mergeFiles(files []FileCoverage) []FileCoverage {
 	for _, f := range uniqueFiles {
 		f.Coverage.Covered = covered[f.File]
 		f.Coverage.Uncovered = uncovered[f.File]
-		f.Coverage.Ratio = ratio(covered[f.File], uncovered[f.File])
 
 		merged = append(merged, f)
 	}
@@ -127,7 +131,6 @@ func mergePackages(files []FileCoverage) []PkgCoverage {
 	for _, p := range uniquePackages {
 		p.Coverage.Covered = covered[p.Pkg]
 		p.Coverage.Uncovered = uncovered[p.Pkg]
-		p.Coverage.Ratio = ratio(covered[p.Pkg], uncovered[p.Pkg])
 
 		merged = append(merged, p)
 	}

--- a/prettycov_test.go
+++ b/prettycov_test.go
@@ -95,8 +95,39 @@ func TestProcessCountsEachStatementOnce(t *testing.T) {
 			for path, want := range tc.want {
 				node := tree.Get(path)
 				require.NotNilf(t, node, "path %q missing from tree", path)
-				assert.InDeltaf(t, want, node.Coverage.Ratio, ratioTolerance, "coverage at %q", path)
+
+				pct, ok := node.Coverage.Ratio()
+				require.Truef(t, ok, "no statements at %q", path)
+				assert.InDeltaf(t, want, pct, ratioTolerance, "coverage at %q", path)
 			}
+		})
+	}
+}
+
+func TestCoverageStatsRatio(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		stats   prettycov.CoverageStats
+		wantPct float64
+		wantOK  bool
+	}{
+		{name: "all covered", stats: prettycov.CoverageStats{Covered: 4}, wantPct: 100, wantOK: true},
+		{name: "none covered", stats: prettycov.CoverageStats{Uncovered: 4}, wantPct: 0, wantOK: true},
+		{name: "partly covered", stats: prettycov.CoverageStats{Covered: 1, Uncovered: 3}, wantPct: 25, wantOK: true},
+		// Not 0%: there is nothing to cover, so there is no percentage to report.
+		{name: "no statements", stats: prettycov.CoverageStats{}, wantPct: 0, wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pct, ok := tc.stats.Ratio()
+
+			assert.Equal(t, tc.wantOK, ok)
+			assert.InDelta(t, tc.wantPct, pct, ratioTolerance)
 		})
 	}
 }

--- a/printer.go
+++ b/printer.go
@@ -22,11 +22,22 @@ func displayTree(w io.Writer, tree *PathTree, depth uint, padding string, root b
 
 	index := 0
 	for k, v := range tree.Children {
-		_, _ = fmt.Fprintf(w, "%s%s - %.2f\n",
-			padding+symbol(root, getBoxType(index, len(tree.Children))), k, v.Coverage.Ratio)
+		_, _ = fmt.Fprintf(w, "%s%s - %s\n",
+			padding+symbol(root, getBoxType(index, len(tree.Children))), k, formatRatio(v.Coverage))
 		displayTree(w, v, depth, padding+symbol(root, childSymbol(index, len(tree.Children))), false, key+"/"+k)
 		index++
 	}
+}
+
+// formatRatio renders a package with no statements as "n/a" rather than a percentage. It used to
+// print "NaN", which is what 0/0 produces in float division.
+func formatRatio(stats CoverageStats) string {
+	pct, ok := stats.Ratio()
+	if !ok {
+		return "n/a"
+	}
+
+	return fmt.Sprintf("%.2f", pct)
 }
 
 type BoxType int

--- a/printer_test.go
+++ b/printer_test.go
@@ -1,0 +1,31 @@
+package prettycov_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/screwyprof/prettycov"
+)
+
+// A package with no statements has no percentage to report, so it renders as "n/a". It used to
+// render as the literal "NaN", which is what 0/0 gives in float division.
+func TestDisplayTreeRendersBothRatioBranches(t *testing.T) {
+	t.Parallel()
+
+	tree := prettycov.Process([]prettycov.FileCoverage{
+		file("m/empty/doc.go", 0, 0),
+		file("m/real/a.go", 3, 1),
+	}, "", "")
+
+	var buf bytes.Buffer
+
+	prettycov.DisplayTree(&buf, tree, 2)
+
+	out := buf.String()
+
+	assert.Contains(t, out, "empty - n/a")
+	assert.Contains(t, out, "real - 75.00")
+	assert.NotContains(t, out, "NaN")
+}


### PR DESCRIPTION
`Ratio` was a derived field **written in four places and read in one** — and three of those writes were immediately overwritten by the next stage.

```
WRITE  parser.go     parse()
WRITE  prettycov.go  mergeFiles()      <- overwrites parse's
WRITE  prettycov.go  mergePackages()   <- overwrites that
WRITE  prettycov.go  rollUp()          <- overwrites that
READ   printer.go
```

Two problems follow from storing it.

**A stored percentage can disagree with the counts beside it.** That is exactly how the roll-up bug worked in #3: it summed `Covered` and `Uncovered` correctly and computed `Ratio` from the wrong operands. As a method that is unrepresentable.

**It put a NaN in the struct.** A package with no statements gave `0/0` = NaN, and NaN does not equal itself, so two identical parses compared unequal — breaking any caller that compares stats, not just the display. That is the RED test in the first commit.

## API

```go
func (c CoverageStats) Ratio() (pct float64, ok bool)
```

`ok` is false when there is nothing to cover, which is **not 0%**. That keeps "no statements" representable without a sentinel value or an enum — the counts already say it.

Breaking: `stats.Ratio` becomes `stats.Ratio()`.

## Knock-on

- `printer.go` is the only reader and now decides how that renders: `n/a` instead of the literal `NaN` it used to print.
- The package-level `ratio()` helper is gone.
- The oracle's assertion that a node's ratio describes its counts is deleted — with a derived value it is a tautology.

## Verified

```
before:  empty - NaN          after:  empty - n/a
```

Real profile unchanged: `delegator 94.01 / pkg 96.41 / scraper 90.00 / web 95.15`. Full suite, `golangci-lint` 0 issues, fmt clean, `make build`.