### PR TITLE
feat(printer): sort output, collapse pass-through dirs, count depth as levels

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,10 +92,12 @@ linters:
       - legacy
       - std-error-handling
     rules:
-      # Exclude some linters from running on test files.
+      # Exclude some linters from running on test files. goconst among them: a path repeated
+      # across two table cases is a fixture, not a constant waiting to be named.
       - linters:
           - dupl
           - funlen
+          - goconst
           - gosec
         path: _test\.go
       - linters:

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Run `prettycov` or `prettycov help` or `prettycov --help` to get build-in usage 
 ### Show coverage summary up to the given depth
 You must specify the path to the coverage profile via `-profile` flag.
 
-You may also specify `-depth` to set how many levels of the tree to show, the way `tree -L` counts them:
+You may also specify `-depth` to set how many levels to show below the top row, the way `tree -L` counts them. Set it past the depth of the tree to drill all the way down and find what is dragging coverage:
 
 ```shell
-❯ prettycov -profile=coverage.out -depth=3
+❯ prettycov -profile=coverage.out -depth=9
  github.com/screwyprof/delegator - 94.01
  ├ pkg - 96.41
  │ ├ clock - 100.00
@@ -41,9 +41,12 @@ You may also specify `-depth` to set how many levels of the tree to show, the wa
  ├ scraper - 90.00
  │ ├ config - 100.00
  │ └ store - 77.97
+ │   ├ dbrow - 100.00
+ │   └ pgxstore - 75.47
  └ web - 95.15
    ├ api - 100.00
    ├ handler - 89.66
+   │ └ bind - 85.71
    ├ store/pgxstore - 96.49
    └ tezos - 100.00
 ```
@@ -53,7 +56,7 @@ Sometimes the project may have a long project path (package path to be more prec
 In this case you may want to replace it with a shorter name:
 
 ```shell
-❯ prettycov -profile=coverage.out -depth=3 -old github.com/screwyprof/delegator -new delegator
+❯ prettycov -profile=coverage.out -depth=2 -old github.com/screwyprof/delegator -new delegator
  delegator - 94.01
  ├ pkg - 96.41
  │ ├ clock - 100.00
@@ -75,7 +78,7 @@ In this case you may want to replace it with a shorter name:
 This is what I created this tool for. You may get a nice top-level package coverage:
 
 ```shell
-❯ prettycov -profile=coverage.out -depth=2
+❯ prettycov -profile=coverage.out
  github.com/screwyprof/delegator - 94.01
  ├ pkg - 96.41
  ├ scraper - 90.00
@@ -85,7 +88,7 @@ This is what I created this tool for. You may get a nice top-level package cover
 ## How it works
 It parses the coverage profile to populate a prefix tree of paths and coverages.
 Then it traverses the tree from the furthermost leaves to top merging the coverage info. 
-Then it draws the tree to the given number of levels. A run of directories that each hold nothing but the next one renders as a single row.
+Then it draws the top row plus `-depth` levels beneath it. A run of directories that each hold nothing but the next one renders as a single row.
 
 ### What's next?
 

--- a/README.md
+++ b/README.md
@@ -27,30 +27,25 @@ Run `prettycov` or `prettycov help` or `prettycov --help` to get build-in usage 
 ### Show coverage summary up to the given depth
 You must specify the path to the coverage profile via `-profile` flag.
 
-You may also specify `-depth` to set the maximum depth (starting from 0) of the resulting tree:
+You may also specify `-depth` to set how many levels of the tree to show, the way `tree -L` counts them:
 
 ```shell
-❯ prettycov -profile=coverage.out -depth=5
- github.com - 91.08
- └ screwyprof - 91.08
-   └ skeleton - 91.08
-     ├ internal - 85.73
-     │ ├ delivery - 100.00
-     │ │ └ rest - 100.00
-     │ ├ app - 57.18
-     │ │ ├ modzap - 16.70
-     │ │ ├ modcfg - 75.00
-     │ │ ├ modrel - 87.00
-     │ │ └ fxlogger - 50.00
-     │ └ adapter - 100.00
-     │   └ postgres - 100.00
-     ├ cert - 100.00
-     │ └ usecase - 100.00
-     │   ├ issuecert - 100.00
-     │   └ viewcert - 100.00
-     └ tests - 87.50
-       └ integration - 87.50
-         └ postgres - 87.50
+❯ prettycov -profile=coverage.out -depth=3
+ github.com/screwyprof/delegator - 94.01
+ ├ pkg - 96.41
+ │ ├ clock - 100.00
+ │ ├ httpkit - 97.50
+ │ ├ logger - 96.88
+ │ ├ pgxdb - 90.00
+ │ └ tzkt - 100.00
+ ├ scraper - 90.00
+ │ ├ config - 100.00
+ │ └ store - 77.97
+ └ web - 95.15
+   ├ api - 100.00
+   ├ handler - 89.66
+   ├ store/pgxstore - 96.49
+   └ tezos - 100.00
 ```
 
 ### Show coverage summary with replaced paths
@@ -58,46 +53,39 @@ Sometimes the project may have a long project path (package path to be more prec
 In this case you may want to replace it with a shorter name:
 
 ```shell
-❯ prettycov -profile=coverage.out -depth=5 -old github.com/screwyprof/skeleton -new unicorn
- unicorn - 91.08
- ├ tests - 87.50
- │ └ integration - 87.50
- │   └ postgres - 87.50
- │     └ app - 87.50
- ├ cert - 100.00
- │ └ usecase - 100.00
- │   ├ issuecert - 100.00
- │   └ viewcert - 100.00
- └ internal - 85.73
-   ├ app - 57.18
-   │ ├ fxlogger - 50.00
-   │ ├ modcfg - 75.00
-   │ ├ modrel - 87.00
-   │ └ modzap - 16.70
-   ├ delivery - 100.00
-   │ └ rest - 100.00
-   │   ├ apierr - 100.00
-   │   ├ req - 100.00
-   │   └ handler - 100.00
-   └ adapter - 100.00
-     └ postgres - 100.00
+❯ prettycov -profile=coverage.out -depth=3 -old github.com/screwyprof/delegator -new delegator
+ delegator - 94.01
+ ├ pkg - 96.41
+ │ ├ clock - 100.00
+ │ ├ httpkit - 97.50
+ │ ├ logger - 96.88
+ │ ├ pgxdb - 90.00
+ │ └ tzkt - 100.00
+ ├ scraper - 90.00
+ │ ├ config - 100.00
+ │ └ store - 77.97
+ └ web - 95.15
+   ├ api - 100.00
+   ├ handler - 89.66
+   ├ store/pgxstore - 96.49
+   └ tezos - 100.00
 ```
 
 ### Getting top-level coverage info
 This is what I created this tool for. You may get a nice top-level package coverage:
 
 ```shell
-❯ prettycov -profile=coverage.out -old github.com/screwyprof/skeleton -new unicorn -depth=1
- unicorn - 91.08
- ├ cert - 100.00
- ├ internal - 85.73
- └ tests - 87.50
+❯ prettycov -profile=coverage.out -depth=2
+ github.com/screwyprof/delegator - 94.01
+ ├ pkg - 96.41
+ ├ scraper - 90.00
+ └ web - 95.15
 ```
 
 ## How it works
 It parses the coverage profile to populate a prefix tree of paths and coverages.
 Then it traverses the tree from the furthermost leaves to top merging the coverage info. 
-Then it draws the tree up to the given depth.
+Then it draws the tree to the given number of levels. A run of directories that each hold nothing but the next one renders as a single row.
 
 ### What's next?
 

--- a/cmd/prettycov/flags.go
+++ b/cmd/prettycov/flags.go
@@ -9,7 +9,7 @@ import (
 const usageMessage = "" +
 	`Prettycov:
 Given a coverage profile produced by 'go test'.
-	go test -coveragepkg=coverage.out ./...
+	go test -coverprofile=coverage.out ./...
 Show coverage summary of the top level packages:
 	prettycov -profile=coverage.out
 Show coverage summary for second level packages:
@@ -40,7 +40,7 @@ func parseFlags() flags {
 		profile = flag.String("profile", "", "coverage profile path")
 		curRoot = flag.String("old", "", "old project's root package")
 		newRoot = flag.String("new", "", "new project's root package")
-		depth   = flag.Uint("depth", 1, "levels of the tree to show, like tree -L")
+		depth   = flag.Uint("depth", 1, "levels to show below the top row, like tree -L")
 		help    = flag.Bool("help", false, "show help")
 		info    = flag.Bool("version", false, "show version")
 	)

--- a/cmd/prettycov/flags.go
+++ b/cmd/prettycov/flags.go
@@ -40,7 +40,7 @@ func parseFlags() flags {
 		profile = flag.String("profile", "", "coverage profile path")
 		curRoot = flag.String("old", "", "old project's root package")
 		newRoot = flag.String("new", "", "new project's root package")
-		depth   = flag.Uint("depth", 1, "nesting to show from top to bottom starting from 0")
+		depth   = flag.Uint("depth", 1, "levels of the tree to show, like tree -L")
 		help    = flag.Bool("help", false, "show help")
 		info    = flag.Bool("version", false, "show version")
 	)

--- a/prettycov.go
+++ b/prettycov.go
@@ -72,6 +72,7 @@ func rollUp(node *PathTree) *PathTree {
 			Uncovered: uncovered,
 		},
 		Children: children,
+		isPkg:    node.isPkg,
 	}
 }
 

--- a/printer.go
+++ b/printer.go
@@ -7,14 +7,15 @@ import (
 	"slices"
 )
 
-// DisplayTree writes tree as an indented report, depth levels deep, counting levels the way
-// `tree -L` does. A collapsed run of directories is the one row it renders as.
+// DisplayTree writes tree as an indented report, showing depth levels below the top row. That is
+// how `tree -L` counts: `tree -L 1` prints the root and one level under it. A collapsed run of
+// directories is the one row it renders as.
 func DisplayTree(w io.Writer, tree *PathTree, depth uint) {
-	displayTree(w, tree, depth, " ", true)
+	displayTree(w, tree, depth, 0, " ", true)
 }
 
-func displayTree(w io.Writer, tree *PathTree, depth uint, padding string, root bool) {
-	if tree == nil || depth == 0 {
+func displayTree(w io.Writer, tree *PathTree, depth, level uint, padding string, root bool) {
+	if tree == nil || level > depth {
 		return
 	}
 
@@ -26,24 +27,19 @@ func displayTree(w io.Writer, tree *PathTree, depth uint, padding string, root b
 
 		_, _ = fmt.Fprintf(w, "%s%s - %s\n",
 			padding+symbol(root, getBoxType(i, len(names))), label, formatRatio(node.Coverage))
-		displayTree(w, node, depth-1, padding+symbol(root, childSymbol(i, len(names))), false)
+		displayTree(w, node, depth, level+1, padding+symbol(root, childSymbol(i, len(names))), false)
 	}
 }
 
 // collapse folds a run of directories that each hold nothing but the next one into a single row,
 // so a module path does not spend three levels on "github.com", "owner", "repo" before reaching
-// anything worth reading. A directory that is a package in its own right is never folded away:
-// it contributes statements, so its totals differ from its child's.
+// anything worth reading. A directory the profile named itself is never folded away, however few
+// statements it holds — a package whose files declare none still deserves its own row.
 func collapse(label string, node *PathTree) (string, *PathTree) {
-	for len(node.Children) == 1 {
-		name := slices.Collect(maps.Keys(node.Children))[0]
-
-		child := node.Children[name]
-		if child.Coverage != node.Coverage {
-			break
+	for !node.isPkg && len(node.Children) == 1 {
+		for name, child := range node.Children {
+			label, node = label+"/"+name, child
 		}
-
-		label, node = label+"/"+name, child
 	}
 
 	return label, node

--- a/printer.go
+++ b/printer.go
@@ -3,30 +3,50 @@ package prettycov
 import (
 	"fmt"
 	"io"
-	"strings"
+	"maps"
+	"slices"
 )
 
+// DisplayTree writes tree as an indented report, depth levels deep, counting levels the way
+// `tree -L` does. A collapsed run of directories is the one row it renders as.
 func DisplayTree(w io.Writer, tree *PathTree, depth uint) {
-	displayTree(w, tree, depth, " ", true, "")
+	displayTree(w, tree, depth, " ", true)
 }
 
-func displayTree(w io.Writer, tree *PathTree, depth uint, padding string, root bool, key string) {
-	curDepth := strings.Count(key, "/")
-	if uint(curDepth) > depth {
+func displayTree(w io.Writer, tree *PathTree, depth uint, padding string, root bool) {
+	if tree == nil || depth == 0 {
 		return
 	}
 
-	if tree == nil {
-		return
-	}
+	// Sorted, because this output gets diffed between runs and map order is randomised.
+	names := slices.Sorted(maps.Keys(tree.Children))
 
-	index := 0
-	for k, v := range tree.Children {
+	for i, name := range names {
+		label, node := collapse(name, tree.Children[name])
+
 		_, _ = fmt.Fprintf(w, "%s%s - %s\n",
-			padding+symbol(root, getBoxType(index, len(tree.Children))), k, formatRatio(v.Coverage))
-		displayTree(w, v, depth, padding+symbol(root, childSymbol(index, len(tree.Children))), false, key+"/"+k)
-		index++
+			padding+symbol(root, getBoxType(i, len(names))), label, formatRatio(node.Coverage))
+		displayTree(w, node, depth-1, padding+symbol(root, childSymbol(i, len(names))), false)
 	}
+}
+
+// collapse folds a run of directories that each hold nothing but the next one into a single row,
+// so a module path does not spend three levels on "github.com", "owner", "repo" before reaching
+// anything worth reading. A directory that is a package in its own right is never folded away:
+// it contributes statements, so its totals differ from its child's.
+func collapse(label string, node *PathTree) (string, *PathTree) {
+	for len(node.Children) == 1 {
+		name := slices.Collect(maps.Keys(node.Children))[0]
+
+		child := node.Children[name]
+		if child.Coverage != node.Coverage {
+			break
+		}
+
+		label, node = label+"/"+name, child
+	}
+
+	return label, node
 }
 
 // formatRatio renders a package with no statements as "n/a" rather than a percentage. It used to

--- a/printer_test.go
+++ b/printer_test.go
@@ -2,6 +2,7 @@ package prettycov_test
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,13 +20,124 @@ func TestDisplayTreeRendersBothRatioBranches(t *testing.T) {
 		file("m/real/a.go", 3, 1),
 	}, "", "")
 
-	var buf bytes.Buffer
-
-	prettycov.DisplayTree(&buf, tree, 2)
-
-	out := buf.String()
+	out := render(t, tree, 2)
 
 	assert.Contains(t, out, "empty - n/a")
 	assert.Contains(t, out, "real - 75.00")
 	assert.NotContains(t, out, "NaN")
+}
+
+// Coverage output gets diffed between CI runs, so the same tree must render byte-identically
+// every time. Ranging over a map does not give that.
+func TestDisplayTreeIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	tree := prettycov.Process(printerFiles(), "", "")
+	first := render(t, tree, 4)
+
+	for range 50 {
+		assert.Equal(t, first, render(t, tree, 4))
+	}
+}
+
+func TestDisplayTreeSortsChildren(t *testing.T) {
+	t.Parallel()
+
+	tree := prettycov.Process(printerFiles(), "", "")
+
+	assert.Equal(t, []string{"m", "alpha/deep", "beta", "gamma"}, nodeNames(render(t, tree, 2)))
+}
+
+// A run of directories that each hold nothing but the next one is one row, not one row each.
+// Without this the default view of any real module is three wasted levels of import path:
+// "github.com" then "screwyprof" then "delegator", each repeating the same percentage.
+func TestDisplayTreeCollapsesPassThroughDirs(t *testing.T) {
+	t.Parallel()
+
+	tree := prettycov.Process([]prettycov.FileCoverage{
+		file("github.com/o/repo/pkg/a.go", 3, 1),
+		file("github.com/o/repo/web/b.go", 1, 1),
+	}, "", "")
+
+	assert.Equal(t, []string{"github.com/o/repo", "pkg", "web"}, nodeNames(render(t, tree, 2)))
+}
+
+// A directory that is a package in its own right keeps its own row even with a single child,
+// otherwise its coverage disappears into the child's label.
+func TestDisplayTreeKeepsDirsThatAreAlsoPackages(t *testing.T) {
+	t.Parallel()
+
+	tree := prettycov.Process([]prettycov.FileCoverage{
+		file("m/x/own.go", 4, 0),
+		file("m/x/sub/s.go", 0, 4),
+	}, "", "")
+
+	assert.Equal(t, []string{"m/x", "sub"}, nodeNames(render(t, tree, 2)))
+}
+
+// -depth counts levels, like `tree -L`: depth=1 is one level, not two. A collapsed run counts as
+// the single row it renders as.
+func TestDisplayTreeDepthCountsLevels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		depth uint
+		want  []string
+	}{
+		{name: "one level", depth: 1, want: []string{"m"}},
+		{name: "two levels", depth: 2, want: []string{"m", "alpha/deep", "beta", "gamma"}},
+		{name: "beyond the tree", depth: 9, want: []string{"m", "alpha/deep", "beta", "gamma"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree := prettycov.Process(printerFiles(), "", "")
+
+			assert.Equal(t, tc.want, nodeNames(render(t, tree, tc.depth)))
+		})
+	}
+}
+
+// m/
+//
+//	├ alpha/deep/   (alpha holds only deep, so the two collapse into one row)
+//	├ beta/
+//	└ gamma/
+func printerFiles() []prettycov.FileCoverage {
+	return []prettycov.FileCoverage{
+		file("m/gamma/g.go", 1, 1),
+		file("m/alpha/deep/d.go", 1, 1),
+		file("m/beta/b.go", 1, 1),
+	}
+}
+
+func render(t *testing.T, tree *prettycov.PathTree, depth uint) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	prettycov.DisplayTree(&buf, tree, depth)
+
+	return buf.String()
+}
+
+// nodeNames pulls the label out of each rendered line, in the order printed.
+func nodeNames(out string) []string {
+	var names []string
+
+	for line := range strings.SplitSeq(strings.TrimRight(out, "\n"), "\n") {
+		idx := strings.LastIndex(line, " - ")
+		if idx < 0 {
+			continue
+		}
+
+		if name := strings.TrimLeft(line[:idx], " ├└│"); name != "" {
+			names = append(names, name)
+		}
+	}
+
+	return names
 }

--- a/printer_test.go
+++ b/printer_test.go
@@ -45,7 +45,7 @@ func TestDisplayTreeSortsChildren(t *testing.T) {
 
 	tree := prettycov.Process(printerFiles(), "", "")
 
-	assert.Equal(t, []string{"m", "alpha/deep", "beta", "gamma"}, nodeNames(render(t, tree, 2)))
+	assert.Equal(t, []string{"m", "alpha/deep", "beta", "gamma"}, nodeNames(render(t, tree, 1)))
 }
 
 // A run of directories that each hold nothing but the next one is one row, not one row each.
@@ -59,7 +59,7 @@ func TestDisplayTreeCollapsesPassThroughDirs(t *testing.T) {
 		file("github.com/o/repo/web/b.go", 1, 1),
 	}, "", "")
 
-	assert.Equal(t, []string{"github.com/o/repo", "pkg", "web"}, nodeNames(render(t, tree, 2)))
+	assert.Equal(t, []string{"github.com/o/repo", "pkg", "web"}, nodeNames(render(t, tree, 1)))
 }
 
 // A directory that is a package in its own right keeps its own row even with a single child,
@@ -67,16 +67,41 @@ func TestDisplayTreeCollapsesPassThroughDirs(t *testing.T) {
 func TestDisplayTreeKeepsDirsThatAreAlsoPackages(t *testing.T) {
 	t.Parallel()
 
-	tree := prettycov.Process([]prettycov.FileCoverage{
-		file("m/x/own.go", 4, 0),
-		file("m/x/sub/s.go", 0, 4),
-	}, "", "")
+	tests := []struct {
+		name  string
+		files []prettycov.FileCoverage
+	}{
+		{
+			name: "own file with statements",
+			files: []prettycov.FileCoverage{
+				file("m/x/own.go", 4, 0),
+				file("m/x/sub/s.go", 0, 4),
+			},
+		},
+		{
+			// A doc.go holding only a package comment has no statements, so m/x's totals equal
+			// its child's. It is still a package and still gets a row.
+			name: "own file with no statements",
+			files: []prettycov.FileCoverage{
+				file("m/x/doc.go", 0, 0),
+				file("m/x/sub/s.go", 3, 1),
+			},
+		},
+	}
 
-	assert.Equal(t, []string{"m/x", "sub"}, nodeNames(render(t, tree, 2)))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree := prettycov.Process(tc.files, "", "")
+
+			assert.Equal(t, []string{"m/x", "sub"}, nodeNames(render(t, tree, 1)))
+		})
+	}
 }
 
-// -depth counts levels, like `tree -L`: depth=1 is one level, not two. A collapsed run counts as
-// the single row it renders as.
+// -depth counts levels below the root row, exactly as `tree -L` does: `tree -L 1` prints the root
+// and one level under it. A collapsed run counts as the single row it renders as.
 func TestDisplayTreeDepthCountsLevels(t *testing.T) {
 	t.Parallel()
 
@@ -85,8 +110,8 @@ func TestDisplayTreeDepthCountsLevels(t *testing.T) {
 		depth uint
 		want  []string
 	}{
-		{name: "one level", depth: 1, want: []string{"m"}},
-		{name: "two levels", depth: 2, want: []string{"m", "alpha/deep", "beta", "gamma"}},
+		{name: "root only", depth: 0, want: []string{"m"}},
+		{name: "one level down", depth: 1, want: []string{"m", "alpha/deep", "beta", "gamma"}},
 		{name: "beyond the tree", depth: 9, want: []string{"m", "alpha/deep", "beta", "gamma"}},
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -7,6 +7,11 @@ type Walker func(key string, value CoverageStats)
 type PathTree struct {
 	Coverage CoverageStats
 	Children map[string]*PathTree
+
+	// isPkg marks a node the profile named directly, as opposed to one created only to hold a
+	// child. It cannot be inferred from Coverage: a package whose files declare no statements
+	// contributes nothing, so its totals equal its child's.
+	isPkg bool
 }
 
 func (n *PathTree) Put(key string, value CoverageStats) bool {
@@ -30,6 +35,7 @@ func (n *PathTree) Put(key string, value CoverageStats) bool {
 	}
 
 	node.Coverage = value
+	node.isPkg = true
 
 	return isNew
 }


### PR DESCRIPTION
The default view was unusable on any real module:

```
$ prettycov -profile=coverage.out
 github.com - 93.95
 └ screwyprof - 93.95
```

Three levels spent on the import path before reaching anything worth reading — which is what `-old`/`-new` existed to work around. Now, with no flags:

```
$ prettycov -profile=coverage.out
 github.com/screwyprof/delegator - 94.01
 ├ pkg - 96.41
 ├ scraper - 90.00
 └ web - 95.15
```

Three changes, each with a test that fails without it.

## 1. Children are sorted

`displayTree` ranged over a map, so all six orderings of three top-level nodes turned up across twenty identical runs. Coverage output gets diffed between CI runs; it has to be stable. Verified: 10 runs, 1 distinct output.

Alphabetical rather than worst-first, deliberately — diffability beats triage for a default. A `-sort` flag is YAGNI until someone asks.

## 2. Pass-through directories collapse

A run of directories that each hold nothing but the next renders as one row. It folds mid-tree too: `web/store/pgxstore`.

A directory the profile named itself is **never** folded away, however few statements it holds. `PathTree` records that directly rather than inferring it from the counts — a package whose files declare no statements (a `doc.go` with only the package comment) contributes `(0,0)`, so its totals equal its child's and a counts-based check folds it away wrongly. The first version of this PR had exactly that bug; see the second commit.

## 3. `-depth` counts levels below the top row

Like `tree -L`: `tree -L 1` prints the root and one level under it. `-depth=0` shows the top row alone.

## Breaking

Output shape changes, and `-depth=N` no longer means what it did. Worth a minor bump rather than a patch.

## Also

- `printer.go` goes from 0% to 100% on every function touched.
- README examples regenerated and checked byte-for-byte against the binary, including a `-depth=9` example that walks past the tree to the badly covered leaves — the reason to reach for this tool.
- The usage text's `go test -coveragepkg` is not a flag; fixed.
- `goconst` excluded from test files: a path repeated across two table cases is a fixture, not a constant.

## Note

An earlier draft of this description claimed `handler` moved from 91.89 to 89.66 in this PR. That was wrong: `main` already prints 89.66, since #3. 91.89 is `handler`'s own package (34/37) excluding its `bind` child; the rolled-up subtree is 52/58 = 89.66. Unchanged by this PR.
