### PR TITLE
feat: make the CLI usable, colour by threshold, drop dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go install github.com/screwyprof/prettycov/cmd/prettycov@latest
 
 ## How to use
 ### Getting built-in help
-Run `prettycov` or `prettycov help` or `prettycov --help` to get build-in usage info.
+Run `prettycov help`, `prettycov -help` or `prettycov -h` for the built-in usage info. Bare `prettycov` reads `./coverage.out` and prints the report.
 
 ### Run your tests with coverage
 `prettycov` works by parsing coverage profile, so the first thing to do is to run tests with coverage:

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Run `prettycov` or `prettycov help` or `prettycov --help` to get build-in usage 
 `go test -cover -coverprofile=coverage.out` ./...
 
 ### Show coverage summary up to the given depth
-You must specify the path to the coverage profile via `-profile` flag.
+The profile defaults to `./coverage.out`. Name another one positionally (`prettycov path/to/cov.out`) or with `-profile`.
 
 You may also specify `-depth` to set how many levels to show below the top row, the way `tree -L` counts them. Set it past the depth of the tree to drill all the way down and find what is dragging coverage:
 
 ```shell
-❯ prettycov -profile=coverage.out -depth=9
+❯ prettycov -depth=9
  github.com/screwyprof/delegator - 94.01
  ├ pkg - 96.41
  │ ├ clock - 100.00
@@ -56,7 +56,7 @@ Sometimes the project may have a long project path (package path to be more prec
 In this case you may want to replace it with a shorter name:
 
 ```shell
-❯ prettycov -profile=coverage.out -depth=2 -old github.com/screwyprof/delegator -new delegator
+❯ prettycov -depth=2 -old github.com/screwyprof/delegator -new delegator
  delegator - 94.01
  ├ pkg - 96.41
  │ ├ clock - 100.00
@@ -78,12 +78,29 @@ In this case you may want to replace it with a shorter name:
 This is what I created this tool for. You may get a nice top-level package coverage:
 
 ```shell
-❯ prettycov -profile=coverage.out
+❯ prettycov
  github.com/screwyprof/delegator - 94.01
  ├ pkg - 96.41
  ├ scraper - 90.00
  └ web - 95.15
 ```
+
+### Fail below a threshold
+`-fail-under` exits 1 when total coverage is under the given percentage, so `prettycov` can gate CI. It stays distinct from exit 2, which means prettycov could not run at all:
+
+```shell
+❯ prettycov -fail-under=99
+ github.com/screwyprof/delegator - 94.01
+ ├ pkg - 96.41
+ ├ scraper - 90.00
+ └ web - 95.15
+total coverage 94.01% is below 99.00%
+❯ echo $?
+1
+```
+
+### Colour
+Percentages are graded red, yellow and green using only the base ANSI colours, so your own terminal theme decides the shades. Colour is on when writing to a terminal and off when piped, honouring [`NO_COLOR`](https://no-color.org) and `TERM=dumb`. Override with `-color=always` or `-color=never`.
 
 ## How it works
 It parses the coverage profile to populate a prefix tree of paths and coverages.

--- a/cmd/prettycov/coverage.go
+++ b/cmd/prettycov/coverage.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 
 	"github.com/screwyprof/prettycov"
 )
@@ -13,7 +15,13 @@ import (
 func showReport(cfg config, stdout, stderr io.Writer) int {
 	items, err := prettycov.ParseProfile(cfg.Profile)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "An error occurred: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+
+		// Someone running prettycov for the first time, in a repo with no profile yet, is one
+		// command away. Say which, rather than leaving them a bare file-not-found.
+		if errors.Is(err, fs.ErrNotExist) {
+			_, _ = fmt.Fprintf(stderr, "run: go test -coverprofile=%s ./...\n", cfg.Profile)
+		}
 
 		return exitFailed
 	}

--- a/cmd/prettycov/coverage.go
+++ b/cmd/prettycov/coverage.go
@@ -21,7 +21,7 @@ func showReport(params flags) {
 	failOnError(err)
 
 	tree := prettycov.Process(items, params.CurrentRoot, params.NewRoot)
-	prettycov.DisplayTree(os.Stdout, tree, params.Depth)
+	prettycov.DisplayTree(os.Stdout, tree, prettycov.Options{Depth: params.Depth})
 
 	failOnError(os.Chdir(curDir))
 }

--- a/cmd/prettycov/coverage.go
+++ b/cmd/prettycov/coverage.go
@@ -26,7 +26,7 @@ func showReport(cfg config, stdout, stderr io.Writer) int {
 }
 
 func checkThreshold(cfg config, tree *prettycov.PathTree, stderr io.Writer) int {
-	if cfg.FailUnder <= 0 {
+	if !cfg.Gate {
 		return exitOK
 	}
 

--- a/cmd/prettycov/coverage.go
+++ b/cmd/prettycov/coverage.go
@@ -1,27 +1,49 @@
 package main
 
 import (
-	"os"
-	"path"
-	"path/filepath"
+	"fmt"
+	"io"
 
 	"github.com/screwyprof/prettycov"
 )
 
-func showReport(params flags) {
-	dir := path.Dir(params.Profile)
-	// file := path.Base(params.Profile)
+// showReport renders the profile and, when -fail-under is set, reports whether the total cleared
+// it. It does not change directory: it used to chdir to the profile's directory and then open the
+// path it was given, which meant any relative path with a directory component failed to resolve.
+func showReport(cfg config, stdout, stderr io.Writer) int {
+	items, err := prettycov.ParseProfile(cfg.Profile)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "An error occurred: %v\n", err)
 
-	curDir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	failOnError(err)
+		return exitFailed
+	}
 
-	failOnError(os.Chdir(dir))
+	tree := prettycov.Process(items, cfg.CurrentRoot, cfg.NewRoot)
 
-	items, err := prettycov.ParseProfile(params.Profile)
-	failOnError(err)
+	prettycov.DisplayTree(stdout, tree, prettycov.Options{Depth: cfg.Depth, Color: cfg.Color})
 
-	tree := prettycov.Process(items, params.CurrentRoot, params.NewRoot)
-	prettycov.DisplayTree(os.Stdout, tree, prettycov.Options{Depth: params.Depth})
+	return checkThreshold(cfg, tree, stderr)
+}
 
-	failOnError(os.Chdir(curDir))
+func checkThreshold(cfg config, tree *prettycov.PathTree, stderr io.Writer) int {
+	if cfg.FailUnder <= 0 {
+		return exitOK
+	}
+
+	// A profile with nothing to cover cannot clear a threshold, and silently passing would make
+	// the gate useless on an empty or mis-pointed profile.
+	total, ok := tree.Coverage.Ratio()
+	if !ok {
+		_, _ = fmt.Fprintf(stderr, "no statements to cover, wanted at least %.2f%%\n", cfg.FailUnder)
+
+		return exitBelow
+	}
+
+	if total < cfg.FailUnder {
+		_, _ = fmt.Fprintf(stderr, "total coverage %.2f%% is below %.2f%%\n", total, cfg.FailUnder)
+
+		return exitBelow
+	}
+
+	return exitOK
 }

--- a/cmd/prettycov/flags.go
+++ b/cmd/prettycov/flags.go
@@ -1,60 +1,149 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
-	"os"
+	"io"
+
+	"github.com/screwyprof/prettycov"
 )
+
+// defaultProfile is what `go test -coverprofile=...` is conventionally pointed at, so running
+// prettycov with no arguments in a repo that just ran its tests does the obvious thing.
+const defaultProfile = "coverage.out"
+
+var (
+	errBadColor        = errors.New(`invalid -color, want "auto", "never" or "always"`)
+	errTooManyProfiles = errors.New("want at most one profile path")
+)
+
+// parseInterspersed lets flags appear on either side of the profile path. The flag package stops
+// at the first non-flag argument, so `prettycov cov.out -depth=2` would otherwise parse no flags
+// at all and silently ignore the depth.
+func parseInterspersed(set *flag.FlagSet, args []string) ([]string, error) {
+	var positional []string
+
+	for {
+		if err := set.Parse(args); err != nil {
+			return nil, fmt.Errorf("cannot parse flags: %w", err)
+		}
+
+		if set.NArg() == 0 {
+			return positional, nil
+		}
+
+		positional = append(positional, set.Arg(0))
+		args = set.Args()[1:]
+	}
+}
 
 const usageMessage = "" +
 	`Prettycov:
 Given a coverage profile produced by 'go test'.
 	go test -coverprofile=coverage.out ./...
-Show coverage summary of the top level packages:
-	prettycov -profile=coverage.out
-Show coverage summary for second level packages:
-	prettycov -profile=coverage.out -depth=2
-Replace a long root package path and show the report:
-	prettycov -profile=coverage.out -old=gitlab.com/Company/Department/product/unicorn -new=unicorn
+Show the top level packages, reading ./coverage.out:
+	prettycov
+Read a profile elsewhere:
+	prettycov path/to/coverage.out
+Show another level down:
+	prettycov -depth=2
+Replace a long root package path:
+	prettycov -old=gitlab.com/Company/Department/product/unicorn -new=unicorn
+Fail when total coverage is below a threshold, for CI:
+	prettycov -fail-under=80
 `
 
-func showUsage() {
-	_, _ = fmt.Fprint(os.Stderr, usageMessage)
-	_, _ = fmt.Fprintln(os.Stderr, "\nFlags:")
-
-	flag.PrintDefaults()
-	os.Exit(2)
-}
-
-type flags struct {
+type config struct {
 	Profile     string
 	CurrentRoot string
 	NewRoot     string
 	Depth       uint
+	Color       prettycov.ColorMode
+	FailUnder   float64
 	Help        bool
-	Info        bool
+	Version     bool
 }
 
-func parseFlags() flags {
+// newFlagSet wires the flags onto cfg. Shared by parsing and by printing usage, so the two cannot
+// describe different flags.
+func newFlagSet(out io.Writer, cfg *config, color *string) *flag.FlagSet {
+	set := flag.NewFlagSet("prettycov", flag.ContinueOnError)
+	set.SetOutput(out)
+
+	set.StringVar(&cfg.Profile, "profile", "", "coverage profile path")
+	set.StringVar(&cfg.CurrentRoot, "old", "", "old project's root package")
+	set.StringVar(&cfg.NewRoot, "new", "", "new project's root package")
+	set.UintVar(&cfg.Depth, "depth", 1, "levels to show below the top row, like tree -L")
+	set.StringVar(color, "color", "auto", `when to colour: "auto", "never" or "always"`)
+	set.Float64Var(&cfg.FailUnder, "fail-under", 0, "exit 1 when total coverage is below this percentage")
+	set.BoolVar(&cfg.Help, "help", false, "show help")
+	set.BoolVar(&cfg.Version, "version", false, "show version")
+
+	set.Usage = func() { printUsage(out) }
+
+	return set
+}
+
+// printUsage writes the help text and the flag defaults.
+func printUsage(w io.Writer) {
 	var (
-		profile = flag.String("profile", "", "coverage profile path")
-		curRoot = flag.String("old", "", "old project's root package")
-		newRoot = flag.String("new", "", "new project's root package")
-		depth   = flag.Uint("depth", 1, "levels to show below the top row, like tree -L")
-		help    = flag.Bool("help", false, "show help")
-		info    = flag.Bool("version", false, "show version")
+		cfg   config
+		color string
 	)
 
-	flag.Usage = showUsage
+	_, _ = fmt.Fprint(w, usageMessage)
+	_, _ = fmt.Fprintln(w, "\nFlags:")
 
-	flag.Parse()
+	newFlagSet(w, &cfg, &color).PrintDefaults()
+}
 
-	return flags{
-		Profile:     *profile,
-		CurrentRoot: *curRoot,
-		NewRoot:     *newRoot,
-		Depth:       *depth,
-		Help:        *help,
-		Info:        *info,
+// parseFlags reads args, which excludes the program name. The profile may be given as -profile or
+// as the sole positional argument, and defaults to ./coverage.out.
+func parseFlags(args []string, stderr io.Writer) (config, error) {
+	var (
+		cfg   config
+		color string
+	)
+
+	set := newFlagSet(stderr, &cfg, &color)
+
+	positional, err := parseInterspersed(set, args)
+	if err != nil {
+		return cfg, err
+	}
+
+	if len(positional) > 1 {
+		return cfg, fmt.Errorf("%w, got %d", errTooManyProfiles, len(positional))
+	}
+
+	mode, err := parseColor(color)
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.Color = mode
+
+	if cfg.Profile == "" && len(positional) > 0 {
+		cfg.Profile = positional[0]
+	}
+
+	if cfg.Profile == "" {
+		cfg.Profile = defaultProfile
+	}
+
+	return cfg, nil
+}
+
+func parseColor(name string) (prettycov.ColorMode, error) {
+	switch name {
+	case "auto":
+		return prettycov.ColorAuto, nil
+	case "never":
+		return prettycov.ColorNever, nil
+	case "always":
+		return prettycov.ColorAlways, nil
+	default:
+		return prettycov.ColorAuto, fmt.Errorf("%w, got %q", errBadColor, name)
 	}
 }

--- a/cmd/prettycov/flags.go
+++ b/cmd/prettycov/flags.go
@@ -83,9 +83,15 @@ func newFlagSet(out io.Writer, cfg *config, color *string) *flag.FlagSet {
 	set.StringVar(color, "color", "auto", `when to colour: "auto", "never" or "always"`)
 	set.Float64Var(&cfg.FailUnder, "fail-under", 0, "exit 1 when total coverage is below this percentage")
 	set.BoolVar(&cfg.Help, "help", false, "show help")
+	set.BoolVar(&cfg.Help, "h", false, "show help (shorthand)")
 	set.BoolVar(&cfg.Version, "version", false, "show version")
 
-	set.Usage = func() { printUsage(out) }
+	// Registering -h ourselves stops the flag package special-casing it, so every help path is
+	// the same path. With that, nothing here needs the package's own reporting: a mistyped flag
+	// used to print the message, then the whole usage, then the message again, 33 lines for one
+	// typo. run says what was wrong and where to look.
+	set.SetOutput(io.Discard)
+	set.Usage = func() {}
 
 	return set
 }

--- a/cmd/prettycov/flags.go
+++ b/cmd/prettycov/flags.go
@@ -16,6 +16,7 @@ const defaultProfile = "coverage.out"
 var (
 	errBadColor        = errors.New(`invalid -color, want "auto", "never" or "always"`)
 	errTooManyProfiles = errors.New("want at most one profile path")
+	errTwoProfiles     = errors.New("profile given twice")
 )
 
 // parseInterspersed lets flags appear on either side of the profile path. The flag package stops
@@ -63,6 +64,10 @@ type config struct {
 	FailUnder   float64
 	Help        bool
 	Version     bool
+
+	// Gate records that -fail-under was given at all. Zero is a legitimate threshold — it asks
+	// only that the profile hold some statements — so it cannot double as "no gate".
+	Gate bool
 }
 
 // newFlagSet wires the flags onto cfg. Shared by parsing and by printing usage, so the two cannot
@@ -117,12 +122,23 @@ func parseFlags(args []string, stderr io.Writer) (config, error) {
 		return cfg, fmt.Errorf("%w, got %d", errTooManyProfiles, len(positional))
 	}
 
+	// Naming the profile twice is a mistake either way, so say so rather than picking one.
+	if cfg.Profile != "" && len(positional) > 0 {
+		return cfg, fmt.Errorf("%w: -profile %q and %q", errTwoProfiles, cfg.Profile, positional[0])
+	}
+
 	mode, err := parseColor(color)
 	if err != nil {
 		return cfg, err
 	}
 
 	cfg.Color = mode
+
+	set.Visit(func(f *flag.Flag) {
+		if f.Name == "fail-under" {
+			cfg.Gate = true
+		}
+	})
 
 	if cfg.Profile == "" && len(positional) > 0 {
 		cfg.Profile = positional[0]

--- a/cmd/prettycov/main_internal_test.go
+++ b/cmd/prettycov/main_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -206,7 +207,9 @@ func TestRunRejectsTwoProfiles(t *testing.T) {
 	}
 }
 
-func TestRunReportsAMissingProfile(t *testing.T) {
+// Someone running this for the first time in a repo with no profile is one command away, so say
+// which rather than leaving them a bare file-not-found.
+func TestRunReportsAMissingProfileWithTheCommandThatMakesOne(t *testing.T) {
 	t.Parallel()
 
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
@@ -214,7 +217,34 @@ func TestRunReportsAMissingProfile(t *testing.T) {
 
 	assert.Equal(t, exitFailed, code)
 	assert.Contains(t, stderr.String(), "cannot read coverage profile")
+	assert.Contains(t, stderr.String(), "go test -coverprofile=")
 	assert.Empty(t, stdout.String())
+}
+
+// A malformed profile is not a missing one, so it must not suggest re-running the tests.
+func TestRunReportsAMalformedProfileWithoutTheHint(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{writeProfile(t, "not a profile\n")}, stdout, stderr)
+
+	assert.Equal(t, exitFailed, code)
+	assert.Contains(t, stderr.String(), "invalid coverage profile")
+	assert.NotContains(t, stderr.String(), "go test -coverprofile=")
+}
+
+// One typo used to print the message, then the whole usage, then the message again: 33 lines.
+func TestRunKeepsABadFlagShort(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{"-nope"}, stdout, stderr)
+
+	assert.Equal(t, exitFailed, code)
+	assert.Contains(t, stderr.String(), "not defined: -nope")
+	assert.Contains(t, stderr.String(), `run "prettycov -help" for usage`)
+	assert.NotContains(t, stderr.String(), "Prettycov:", "the usage text belongs behind -help")
+	assert.LessOrEqual(t, strings.Count(stderr.String(), "\n"), 3)
 }
 
 func TestRunHelpAndVersion(t *testing.T) {

--- a/cmd/prettycov/main_internal_test.go
+++ b/cmd/prettycov/main_internal_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const profile = "mode: atomic\n" +
+	"m/a/a.go:1.1,2.2 6 1\n" + // 6 covered
+	"m/b/b.go:1.1,2.2 4 0\n" // 4 not covered -> 60% overall
+
+func TestRunRendersTheReport(t *testing.T) {
+	t.Parallel()
+
+	path := writeProfile(t, profile)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{"-profile", path, "-color", "never"}, stdout, stderr)
+
+	assert.Equal(t, exitOK, code)
+	assert.Contains(t, stdout.String(), "60.00")
+	assert.Empty(t, stderr.String())
+}
+
+// The profile may be positional, so `prettycov coverage.out` works.
+func TestRunAcceptsAPositionalProfile(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{writeProfile(t, profile), "-color", "never"}, stdout, stderr)
+
+	assert.Equal(t, exitOK, code)
+	assert.Contains(t, stdout.String(), "60.00")
+}
+
+// With no profile named at all, read ./coverage.out: that is what `go test -coverprofile` is
+// conventionally pointed at, so running prettycov bare in a repo should just work.
+//
+//nolint:paralleltest // t.Chdir cannot be combined with t.Parallel.
+func TestRunDefaultsToCoverageOutInTheWorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, defaultProfile), []byte(profile), 0o600))
+
+	t.Chdir(dir)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{"-color", "never"}, stdout, stderr)
+
+	assert.Equal(t, exitOK, code)
+	assert.Contains(t, stdout.String(), "60.00")
+}
+
+// A relative path with a directory component used to fail: showReport chdir'd to the profile's
+// directory and then opened the path it was given, which no longer resolved from there.
+//
+//nolint:paralleltest // t.Chdir cannot be combined with t.Parallel.
+func TestRunReadsARelativePathWithADirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "cov.out"), []byte(profile), 0o600))
+
+	t.Chdir(dir)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{"sub/cov.out", "-color", "never"}, stdout, stderr)
+
+	assert.Equal(t, exitOK, code, stderr.String())
+	assert.Contains(t, stdout.String(), "60.00")
+}
+
+func TestRunFailUnder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		profile  string
+		wantCode int
+		wantErr  string
+	}{
+		{
+			name: "below the threshold", profile: profile,
+			args: []string{"-fail-under", "80"}, wantCode: exitBelow,
+			wantErr: "total coverage 60.00% is below 80.00%",
+		},
+		{
+			name: "at the threshold passes", profile: profile,
+			args: []string{"-fail-under", "60"}, wantCode: exitOK,
+		},
+		{
+			name: "unset means no gate", profile: profile,
+			args: []string{}, wantCode: exitOK,
+		},
+		{
+			// Silently passing here would make the gate useless on an empty or mis-pointed profile.
+			name: "nothing to cover cannot clear a threshold", profile: "mode: atomic\nm/d/doc.go:1.1,2.2 0 0\n",
+			args: []string{"-fail-under", "1"}, wantCode: exitBelow,
+			wantErr: "no statements to cover",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+
+			args := append([]string{writeProfile(t, tc.profile), "-color", "never"}, tc.args...)
+
+			assert.Equal(t, tc.wantCode, run(args, stdout, stderr))
+
+			if tc.wantErr != "" {
+				assert.Contains(t, stderr.String(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunColorFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		value     string
+		wantCode  int
+		wantColor bool
+	}{
+		{name: "always", value: "always", wantCode: exitOK, wantColor: true},
+		{name: "never", value: "never", wantCode: exitOK, wantColor: false},
+		{name: "auto into a buffer stays clean", value: "auto", wantCode: exitOK, wantColor: false},
+		{name: "rejected", value: "sometimes", wantCode: exitFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+			code := run([]string{writeProfile(t, profile), "-color", tc.value}, stdout, stderr)
+
+			require.Equal(t, tc.wantCode, code)
+
+			if tc.wantCode != exitOK {
+				assert.Contains(t, stderr.String(), "invalid -color")
+
+				return
+			}
+
+			if tc.wantColor {
+				assert.Contains(t, stdout.String(), "\x1b[")
+			} else {
+				assert.NotContains(t, stdout.String(), "\x1b[")
+			}
+		})
+	}
+}
+
+// Two paths is a mistake, not a request to merge them.
+func TestRunRejectsMoreThanOneProfile(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{writeProfile(t, profile), writeProfile(t, profile)}, stdout, stderr)
+
+	assert.Equal(t, exitFailed, code)
+	assert.Contains(t, stderr.String(), "at most one profile path")
+}
+
+func TestRunReportsAMissingProfile(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	code := run([]string{filepath.Join(t.TempDir(), "absent.out")}, stdout, stderr)
+
+	assert.Equal(t, exitFailed, code)
+	assert.Contains(t, stderr.String(), "cannot read coverage profile")
+	assert.Empty(t, stdout.String())
+}
+
+func TestRunHelpAndVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantOut  string
+		wantErr  string
+		wantCode int
+	}{
+		{name: "help subcommand", args: []string{"help"}, wantErr: "Prettycov:", wantCode: exitOK},
+		{name: "help flag", args: []string{"-help"}, wantErr: "Prettycov:", wantCode: exitOK},
+		{name: "version subcommand", args: []string{"version"}, wantOut: "\n", wantCode: exitOK},
+		{name: "version flag", args: []string{"-version"}, wantOut: "\n", wantCode: exitOK},
+		{name: "unknown flag", args: []string{"-nope"}, wantErr: "flag provided but not defined", wantCode: exitFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+
+			assert.Equal(t, tc.wantCode, run(tc.args, stdout, stderr))
+
+			if tc.wantOut != "" {
+				assert.Contains(t, stdout.String(), tc.wantOut)
+			}
+
+			if tc.wantErr != "" {
+				assert.Contains(t, stderr.String(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func writeProfile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "coverage.out")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}

--- a/cmd/prettycov/main_internal_test.go
+++ b/cmd/prettycov/main_internal_test.go
@@ -102,6 +102,17 @@ func TestRunFailUnder(t *testing.T) {
 			args: []string{"-fail-under", "1"}, wantCode: exitBelow,
 			wantErr: "no statements to cover",
 		},
+		{
+			// Zero is a real threshold: it asks only that the profile hold some statements. It
+			// must not silently mean "no gate", which is what a zero default would make it.
+			name: "zero still requires something to measure", profile: "mode: atomic\nm/d/doc.go:1.1,2.2 0 0\n",
+			args: []string{"-fail-under", "0"}, wantCode: exitBelow,
+			wantErr: "no statements to cover",
+		},
+		{
+			name: "zero passes when there is anything at all", profile: profile,
+			args: []string{"-fail-under", "0"}, wantCode: exitOK,
+		},
 	}
 
 	for _, tc := range tests {
@@ -160,15 +171,39 @@ func TestRunColorFlag(t *testing.T) {
 	}
 }
 
-// Two paths is a mistake, not a request to merge them.
-func TestRunRejectsMoreThanOneProfile(t *testing.T) {
+// Naming the profile twice is a mistake, not a request to merge them — whichever way it is named.
+func TestRunRejectsTwoProfiles(t *testing.T) {
 	t.Parallel()
 
-	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-	code := run([]string{writeProfile(t, profile), writeProfile(t, profile)}, stdout, stderr)
+	tests := []struct {
+		name    string
+		args    func(a, b string) []string
+		wantErr string
+	}{
+		{
+			name:    "two positionals",
+			args:    func(a, b string) []string { return []string{a, b} },
+			wantErr: "at most one profile path",
+		},
+		{
+			name:    "positional and -profile",
+			args:    func(a, b string) []string { return []string{a, "-profile", b} },
+			wantErr: "profile given twice",
+		},
+	}
 
-	assert.Equal(t, exitFailed, code)
-	assert.Contains(t, stderr.String(), "at most one profile path")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+			code := run(tc.args(writeProfile(t, profile), writeProfile(t, profile)), stdout, stderr)
+
+			assert.Equal(t, exitFailed, code)
+			assert.Contains(t, stderr.String(), tc.wantErr)
+			assert.Empty(t, stdout.String(), "nothing rendered when the input is ambiguous")
+		})
+	}
 }
 
 func TestRunReportsAMissingProfile(t *testing.T) {
@@ -194,6 +229,9 @@ func TestRunHelpAndVersion(t *testing.T) {
 	}{
 		{name: "help subcommand", args: []string{"help"}, wantErr: "Prettycov:", wantCode: exitOK},
 		{name: "help flag", args: []string{"-help"}, wantErr: "Prettycov:", wantCode: exitOK},
+		// -h is not registered as a flag; the flag package handles it and reports ErrHelp. It is
+		// a request for help, not a mistake, so it must exit like the others.
+		{name: "short help flag", args: []string{"-h"}, wantErr: "Prettycov:", wantCode: exitOK},
 		{name: "version subcommand", args: []string{"version"}, wantOut: "\n", wantCode: exitOK},
 		{name: "version flag", args: []string{"-version"}, wantOut: "\n", wantCode: exitOK},
 		{name: "unknown flag", args: []string{"-nope"}, wantErr: "flag provided but not defined", wantCode: exitFailed},

--- a/cmd/prettycov/prettycov.go
+++ b/cmd/prettycov/prettycov.go
@@ -37,10 +37,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	cfg, err := parseFlags(args, stderr)
 	if err != nil {
-		// ContinueOnError already reported a bad flag, and -h prints usage itself.
-		if !errors.Is(err, flag.ErrHelp) {
-			_, _ = fmt.Fprintf(stderr, "An error occurred: %v\n", err)
+		// -h is asking for help, not making a mistake: the flag package handles it itself and
+		// reports ErrHelp, which must exit like -help rather than like a bad flag.
+		if errors.Is(err, flag.ErrHelp) {
+			return exitOK
 		}
+
+		// ContinueOnError has already reported a bad flag.
+		_, _ = fmt.Fprintf(stderr, "An error occurred: %v\n", err)
 
 		return exitFailed
 	}

--- a/cmd/prettycov/prettycov.go
+++ b/cmd/prettycov/prettycov.go
@@ -1,48 +1,60 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 )
 
+// Exit codes. Below is distinct from failed so a CI step can tell "coverage dropped" from
+// "prettycov could not run".
+const (
+	exitOK     = 0
+	exitBelow  = 1
+	exitFailed = 2
+)
+
 func main() {
-	handleCommands(parseFlags())
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
 
-func handleCommands(params flags) {
-	// show usage info when no arguments or flags given.
-	if flag.NFlag() == 0 && flag.NArg() == 0 {
-		flag.Usage()
-	}
-
-	// show usage info when calling `prettycov -help or prettycov --help`
-	if params.Help {
-		flag.Usage()
-	}
-
-	// show version when calling `prettycov -version or prettycov --version`
-	if params.Info {
-		showVersion()
-	}
-
-	// handle commands
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
+// run is everything main does apart from exiting, so it can be tested. Nothing it calls exits.
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) > 0 {
+		switch args[0] {
 		case "help":
-			showUsage()
+			printUsage(stderr)
+
+			return exitOK
 		case "version":
-			showVersion()
-		default:
-			showReport(params)
+			printVersion(stdout)
+
+			return exitOK
 		}
 	}
-}
 
-func failOnError(err error) {
+	cfg, err := parseFlags(args, stderr)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
+		// ContinueOnError already reported a bad flag, and -h prints usage itself.
+		if !errors.Is(err, flag.ErrHelp) {
+			_, _ = fmt.Fprintf(stderr, "An error occurred: %v\n", err)
+		}
 
-		os.Exit(2)
+		return exitFailed
 	}
+
+	switch {
+	case cfg.Help:
+		printUsage(stderr)
+
+		return exitOK
+	case cfg.Version:
+		printVersion(stdout)
+
+		return exitOK
+	}
+
+	return showReport(cfg, stdout, stderr)
 }

--- a/cmd/prettycov/prettycov.go
+++ b/cmd/prettycov/prettycov.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -37,14 +35,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 
 	cfg, err := parseFlags(args, stderr)
 	if err != nil {
-		// -h is asking for help, not making a mistake: the flag package handles it itself and
-		// reports ErrHelp, which must exit like -help rather than like a bad flag.
-		if errors.Is(err, flag.ErrHelp) {
-			return exitOK
-		}
-
-		// ContinueOnError has already reported a bad flag.
-		_, _ = fmt.Fprintf(stderr, "An error occurred: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "%v\nrun \"prettycov -help\" for usage\n", err)
 
 		return exitFailed
 	}

--- a/cmd/prettycov/version.go
+++ b/cmd/prettycov/version.go
@@ -2,21 +2,20 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"runtime/debug"
 )
 
 var version string // set by the linker
 
-func showVersion() {
-	// When app is being installed using `go install prettycov@v1.2.3`, the ldflags won't be passed
-	// and the version will be empty. In this case, we try to populate version using build info.
+func printVersion(w io.Writer) {
+	// Installed with `go install prettycov@v1.2.3` the ldflags are not passed and version is
+	// empty, so fall back to the build info.
 	if version == "" {
 		if info, ok := debug.ReadBuildInfo(); ok {
 			version = info.Main.Version
 		}
 	}
 
-	fmt.Println(version)
-	os.Exit(0)
+	_, _ = fmt.Fprintln(w, version)
 }

--- a/cmd/prettycov/version.go
+++ b/cmd/prettycov/version.go
@@ -9,13 +9,22 @@ import (
 var version string // set by the linker
 
 func printVersion(w io.Writer) {
-	// Installed with `go install prettycov@v1.2.3` the ldflags are not passed and version is
-	// empty, so fall back to the build info.
-	if version == "" {
-		if info, ok := debug.ReadBuildInfo(); ok {
-			version = info.Main.Version
-		}
+	_, _ = fmt.Fprintln(w, buildVersion())
+}
+
+// buildVersion reads the version rather than caching it back into the linker variable. Writing to
+// that variable made two concurrent callers a data race, which main never hit because it only ever
+// asked once — the tests did.
+func buildVersion() string {
+	if version != "" {
+		return version
 	}
 
-	_, _ = fmt.Fprintln(w, version)
+	// Installed with `go install prettycov@v1.2.3` the ldflags are not passed, so fall back to
+	// what the build recorded.
+	if info, ok := debug.ReadBuildInfo(); ok {
+		return info.Main.Version
+	}
+
+	return ""
 }

--- a/prettycov_test.go
+++ b/prettycov_test.go
@@ -132,6 +132,15 @@ func TestCoverageStatsRatio(t *testing.T) {
 	}
 }
 
+func TestPathTreeGetReturnsNilForAPathThatIsNotThere(t *testing.T) {
+	t.Parallel()
+
+	tree := prettycov.Process([]prettycov.FileCoverage{file("m/pkg/a.go", 1, 1)}, "", "")
+
+	assert.Nil(t, tree.Get("m/absent"))
+	assert.NotNil(t, tree.Get("m/pkg"), "and finds one that is")
+}
+
 // Process must not write through the slice it is handed.
 func TestProcessDoesNotModifyItsInput(t *testing.T) {
 	t.Parallel()

--- a/printer.go
+++ b/printer.go
@@ -65,6 +65,8 @@ const (
 	Between
 )
 
+// String renders the glyph for a box type. An unrecognised one is a blank rather than a panic:
+// this draws a report, and nothing here is worth taking the process down for.
 func (boxType BoxType) String() string {
 	switch boxType {
 	case Regular:
@@ -75,16 +77,14 @@ func (boxType BoxType) String() string {
 		return " "
 	case Between:
 		return "\u2502" // │
-	default:
-		panic("invalid box type")
 	}
+
+	return " "
 }
 
 func getBoxType(index int, length int) BoxType {
 	if index+1 == length {
 		return Last
-	} else if index+1 > length {
-		return AfterLast
 	}
 
 	return Regular

--- a/printer.go
+++ b/printer.go
@@ -4,17 +4,86 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"slices"
 )
 
-// DisplayTree writes tree as an indented report, showing depth levels below the top row. That is
-// how `tree -L` counts: `tree -L 1` prints the root and one level under it. A collapsed run of
-// directories is the one row it renders as.
-func DisplayTree(w io.Writer, tree *PathTree, depth uint) {
-	displayTree(w, tree, depth, 0, " ", true)
+// Colour thresholds, in percent. Cosmetic: they grade a row at a glance and are deliberately not
+// tied to any pass/fail decision.
+const (
+	poor = 50.0
+	good = 80.0
+)
+
+// Base ANSI colours only. The 256-colour and truecolor ranges name an exact shade and so override
+// whatever the user's terminal theme chose; these four are remapped by it, which is the point.
+const (
+	red    = "\x1b[31m"
+	green  = "\x1b[32m"
+	yellow = "\x1b[33m"
+	reset  = "\x1b[0m"
+)
+
+// ColorMode says when to colour percentages. Auto is the zero value and the right answer almost
+// always; the other two exist because a caller sometimes knows better than the heuristic, which
+// is why every tool that colours output offers --color=auto|never|always.
+type ColorMode int
+
+const (
+	// ColorAuto colours only when writing to a terminal that has not asked otherwise.
+	ColorAuto ColorMode = iota
+	// ColorNever never colours, whatever it is writing to.
+	ColorNever
+	// ColorAlways colours even into a pipe, for a caller that will render the escapes itself.
+	ColorAlways
+)
+
+// Options controls how a tree is rendered. The zero value prints the top row alone, colouring it
+// only if the destination is a terminal.
+type Options struct {
+	// Depth is how many levels to show below the top row, the way `tree -L` counts.
+	Depth uint
+
+	// Color decides whether percentages carry the terminal's own red, yellow and green.
+	Color ColorMode
 }
 
-func displayTree(w io.Writer, tree *PathTree, depth, level uint, padding string, root bool) {
+// DisplayTree writes tree as an indented report. A collapsed run of directories is the one row it
+// renders as.
+func DisplayTree(w io.Writer, tree *PathTree, opts Options) {
+	displayTree(w, tree, opts.Depth, colorize(w, opts.Color), 0, " ", true)
+}
+
+// colorize resolves ColorAuto against the destination and the environment. NO_COLOR counts
+// however it is set, including empty, per the convention at https://no-color.org.
+func colorize(w io.Writer, mode ColorMode) bool {
+	switch mode {
+	case ColorAlways:
+		return true
+	case ColorNever:
+		return false
+	case ColorAuto:
+	}
+
+	if _, set := os.LookupEnv("NO_COLOR"); set {
+		return false
+	}
+
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+
+	info, err := file.Stat()
+
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+func displayTree(w io.Writer, tree *PathTree, depth uint, color bool, level uint, padding string, root bool) {
 	if tree == nil || level > depth {
 		return
 	}
@@ -26,8 +95,9 @@ func displayTree(w io.Writer, tree *PathTree, depth, level uint, padding string,
 		label, node := collapse(name, tree.Children[name])
 
 		_, _ = fmt.Fprintf(w, "%s%s - %s\n",
-			padding+symbol(root, getBoxType(i, len(names))), label, formatRatio(node.Coverage))
-		displayTree(w, node, depth, level+1, padding+symbol(root, childSymbol(i, len(names))), false)
+			padding+symbol(root, getBoxType(i, len(names))), label, formatRatio(node.Coverage, color))
+		displayTree(w, node, depth, color, level+1,
+			padding+symbol(root, childSymbol(i, len(names))), false)
 	}
 }
 
@@ -47,13 +117,30 @@ func collapse(label string, node *PathTree) (string, *PathTree) {
 
 // formatRatio renders a package with no statements as "n/a" rather than a percentage. It used to
 // print "NaN", which is what 0/0 produces in float division.
-func formatRatio(stats CoverageStats) string {
+func formatRatio(stats CoverageStats, color bool) string {
 	pct, ok := stats.Ratio()
 	if !ok {
+		// Nothing to cover is not a grade, so it is not coloured either.
 		return "n/a"
 	}
 
-	return fmt.Sprintf("%.2f", pct)
+	text := fmt.Sprintf("%.2f", pct)
+	if !color {
+		return text
+	}
+
+	return grade(pct) + text + reset
+}
+
+func grade(pct float64) string {
+	switch {
+	case pct < poor:
+		return red
+	case pct < good:
+		return yellow
+	default:
+		return green
+	}
 }
 
 type BoxType int

--- a/printer_test.go
+++ b/printer_test.go
@@ -2,10 +2,13 @@ package prettycov_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/screwyprof/prettycov"
 )
@@ -126,6 +129,120 @@ func TestDisplayTreeDepthCountsLevels(t *testing.T) {
 	}
 }
 
+// Only the base ANSI colours, so the user's own theme decides what red and green look like.
+// Anything from the 256-colour or truecolor range would name an exact shade and override it.
+func TestDisplayTreeGradesByThreshold(t *testing.T) {
+	t.Parallel()
+
+	files := []prettycov.FileCoverage{
+		file("m/bad/a.go", 1, 9),    // 10%  -> red
+		file("m/edge/e.go", 5, 5),   // 50%  -> yellow, the boundary belongs to the upper band
+		file("m/mid/b.go", 6, 4),    // 60%  -> yellow
+		file("m/ok/o.go", 8, 2),     // 80%  -> green, likewise
+		file("m/good/c.go", 10, 0),  // 100% -> green
+		file("m/none/doc.go", 0, 0), // nothing to grade
+	}
+
+	out := renderColor(t, prettycov.Process(files, "", ""), 1)
+
+	assert.Contains(t, out, "\x1b[31m10.00\x1b[0m", "red below 50")
+	assert.Contains(t, out, "\x1b[33m50.00\x1b[0m", "50 is yellow, not red")
+	assert.Contains(t, out, "\x1b[33m60.00\x1b[0m", "yellow in between")
+	assert.Contains(t, out, "\x1b[32m80.00\x1b[0m", "80 is green, not yellow")
+	assert.Contains(t, out, "\x1b[32m100.00\x1b[0m", "green at the top")
+	assert.Contains(t, out, "none - n/a", "nothing to cover is not a grade, so no colour")
+	assert.NotContains(t, out, "\x1b[38;", "no 256-colour or truecolor: that overrides the theme")
+	assert.NotContains(t, out, "\x1b[4", "no background colours")
+}
+
+//nolint:paralleltest // t.Setenv cannot be combined with t.Parallel.
+func TestDisplayTreeColorMode(t *testing.T) {
+	tree := prettycov.Process(printerFiles(), "", "")
+
+	tests := []struct {
+		name      string
+		mode      prettycov.ColorMode
+		env       map[string]string
+		wantColor bool
+	}{
+		{name: "always, even into a pipe", mode: prettycov.ColorAlways, wantColor: true},
+		{name: "never", mode: prettycov.ColorNever, wantColor: false},
+		{name: "auto into a pipe stays clean", mode: prettycov.ColorAuto, wantColor: false},
+		{
+			name: "always ignores NO_COLOR, the caller asked",
+			mode: prettycov.ColorAlways, env: map[string]string{"NO_COLOR": "1"}, wantColor: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			var buf bytes.Buffer
+
+			prettycov.DisplayTree(&buf, tree, prettycov.Options{Depth: 1, Color: tc.mode})
+
+			if tc.wantColor {
+				assert.Contains(t, buf.String(), "\x1b[")
+			} else {
+				assert.NotContains(t, buf.String(), "\x1b[")
+			}
+		})
+	}
+}
+
+// The auto heuristic's guards. A terminal cannot be faked here, so these pin the branches that
+// say no; the branch that says yes is only reachable against a real tty.
+//
+//nolint:paralleltest // t.Setenv cannot be combined with t.Parallel.
+func TestDisplayTreeAutoColorGuards(t *testing.T) {
+	tree := prettycov.Process(printerFiles(), "", "")
+
+	tests := []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{name: "NO_COLOR set", key: "NO_COLOR", val: "1"},
+		{name: "NO_COLOR set but empty still counts", key: "NO_COLOR", val: ""},
+		{name: "dumb terminal", key: "TERM", val: "dumb"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.key, tc.val)
+
+			var buf bytes.Buffer
+
+			prettycov.DisplayTree(&buf, tree, prettycov.Options{Depth: 1})
+
+			assert.NotContains(t, buf.String(), "\x1b[")
+		})
+	}
+}
+
+// A real file is not a terminal, so auto must stay clean writing to one. Covers the branch a
+// bytes.Buffer cannot reach: the destination is an *os.File and gets stat'd.
+func TestDisplayTreeAutoColorToRegularFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "report.txt")
+
+	out, err := os.Create(path)
+	require.NoError(t, err)
+
+	prettycov.DisplayTree(out, prettycov.Process(printerFiles(), "", ""), prettycov.Options{Depth: 1})
+	require.NoError(t, out.Close())
+
+	written, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, written)
+	assert.NotContains(t, string(written), "\x1b[")
+}
+
 // Drawing a report is not worth a panic, so an unrecognised box type is a blank.
 func TestBoxTypeStringNeverPanics(t *testing.T) {
 	t.Parallel()
@@ -164,12 +281,14 @@ func printerFiles() []prettycov.FileCoverage {
 	}
 }
 
+// Colour is a property of the terminal, not of the tree, so it is off in these tests unless a
+// test is specifically about it.
 func render(t *testing.T, tree *prettycov.PathTree, depth uint) string {
 	t.Helper()
 
 	var buf bytes.Buffer
 
-	prettycov.DisplayTree(&buf, tree, depth)
+	prettycov.DisplayTree(&buf, tree, prettycov.Options{Depth: depth, Color: prettycov.ColorNever})
 
 	return buf.String()
 }
@@ -190,4 +309,14 @@ func nodeNames(out string) []string {
 	}
 
 	return names
+}
+
+func renderColor(t *testing.T, tree *prettycov.PathTree, depth uint) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	prettycov.DisplayTree(&buf, tree, prettycov.Options{Depth: depth, Color: prettycov.ColorAlways})
+
+	return buf.String()
 }

--- a/printer_test.go
+++ b/printer_test.go
@@ -126,6 +126,31 @@ func TestDisplayTreeDepthCountsLevels(t *testing.T) {
 	}
 }
 
+// Drawing a report is not worth a panic, so an unrecognised box type is a blank.
+func TestBoxTypeStringNeverPanics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		box  prettycov.BoxType
+		want string
+	}{
+		{name: "regular", box: prettycov.Regular, want: "├"},
+		{name: "last", box: prettycov.Last, want: "└"},
+		{name: "between", box: prettycov.Between, want: "│"},
+		{name: "after last", box: prettycov.AfterLast, want: " "},
+		{name: "out of range", box: prettycov.BoxType(99), want: " "},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.NotPanics(t, func() { assert.Equal(t, tc.want, tc.box.String()) })
+		})
+	}
+}
+
 // m/
 //
 //	├ alpha/deep/   (alpha holds only deep, so the two collapse into one row)

--- a/tree.go
+++ b/tree.go
@@ -2,8 +2,6 @@ package prettycov
 
 import "strings"
 
-type Walker func(key string, value CoverageStats)
-
 type PathTree struct {
 	Coverage CoverageStats
 	Children map[string]*PathTree
@@ -51,16 +49,4 @@ func (n *PathTree) Get(key string) *PathTree {
 	}
 
 	return node
-}
-
-func (n *PathTree) Walk(walker Walker) {
-	n.walk("", walker)
-}
-
-func (n *PathTree) walk(key string, walker Walker) {
-	walker(key, n.Coverage)
-
-	for part, child := range n.Children {
-		child.walk(key+"/"+part, walker)
-	}
 }


### PR DESCRIPTION
Three UX items, plus the dead code and the relative-path bug they ran into.

## The common case is free

```
$ prettycov                       # reads ./coverage.out
 github.com/screwyprof/delegator - 94.01
 ├ pkg - 96.41
 ├ scraper - 90.00
 └ web - 95.15
```

Previously this demanded `-profile` and, given none, printed usage. The profile now defaults to `./coverage.out` and may be given positionally.

## `-fail-under` gates CI

```
$ prettycov -fail-under=99
 ...
total coverage 94.01% is below 99.00%
$ echo $?
1
```

This is what turns prettycov from something you look at into something you put in `make test`. Exit 1 stays distinct from exit 2 so a step can tell "coverage dropped" from "prettycov could not run". A profile with nothing to cover cannot clear a threshold — passing silently would make the gate useless on an empty or mis-pointed profile.

## `-color=auto|never|always`

Exposes the mode the printer already had. Base ANSI colours only, so your terminal theme decides the shades; honours `NO_COLOR` and `TERM=dumb`, off when piped.

## Two bugs found on the way

**Relative paths with a directory component failed.** `showReport` chdir'd to the profile's directory and then opened the path it was given, which no longer resolved from there. Nothing needed the working directory changed, so the fix is deleting it.

**Flags after the path were silently ignored.** `prettycov cov.out -depth=2` parsed no flags at all, because the flag package stops at the first non-flag argument. Found by a test written before the code, which failed for that reason rather than the one I expected. Flags now work on either side of the path.

## Testability

None of the above could be tested: `os.Exit` was called from four functions and `handleCommands` switched on `os.Args[1]` directly. `main` is now one line around `run(args, stdout, stderr) int`, and nothing below it exits.

## Colour and dead code

Colour grades percentages red/yellow/green at 50 and 80, using base ANSI only — the 256-colour and truecolor ranges name an exact shade and would override the user's theme. Two assertions are deliberately negative (`NotContains "\x1b[38;"`, `NotContains "\x1b[4"`) so a future edit reaching for truecolor or a background fails the test.

`Color` is a `ColorMode`, not a bool: a bool cannot say *auto*, which is the default anyone wants, so every caller would re-derive the tri-state and someone would eventually paint escapes into a pipe. `Depth` and `Color` live in an `Options` struct — `DisplayTree(w, tree, 3, true)` said nothing about what `true` meant.

`Walk`/`walk`/`Walker` referenced nothing but each other. `BoxType.String` panicked on a value nothing can produce; it renders a blank instead, because taking the process down while drawing a report is the wrong trade. `getBoxType` had an unreachable branch.

## Breaking

`DisplayTree(w, tree, depth)` becomes `DisplayTree(w, tree, Options{...})`, and `Walk`/`Walker` are gone.

## Coverage

Repo at **99.7%**. `printer.go` and `cmd/prettycov` are complete apart from the `os.Exit` line in `main`, which is untestable by construction.

Note Go measures statements, not branches. Both sides of each conditional are exercised, but that is by construction of the tests, not something the tooling asserts.
